### PR TITLE
Add Serde support for Fp, Fp2 & Fp6

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -4,6 +4,9 @@
 use core::convert::TryFrom;
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use serde::{
+    self, de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,
+};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -48,6 +51,56 @@ impl PartialEq for Fp {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).unwrap_u8() == 1
+    }
+}
+
+
+impl Serialize for Fp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tup = serializer.serialize_seq(Some(48))?;
+        let fp_as_bytes = self.to_bytes();
+        for i in 0..48 {
+            tup.serialize_element(&fp_as_bytes[i])?;
+        }
+        tup.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Fp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FpVisitor;
+
+        impl<'de> Visitor<'de> for FpVisitor {
+            type Value = Fp;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("a prover key with valid powers per points")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Fp, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut bytes = [0u8; 48];
+                for i in 0..48 {
+                    bytes[i] = seq.next_element()?
+                        .ok_or(serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
+                }
+                let res = Fp::from_bytes(&bytes);
+                if res.is_some().unwrap_u8() == 1u8 {return Ok(res.unwrap())}
+                else {return Err(serde::de::Error::custom(
+                    &"fp was not canonically encoded"
+                ))}
+            }
+        }
+
+        deserializer.deserialize_seq(FpVisitor)
     }
 }
 
@@ -856,4 +909,14 @@ fn test_lexicographic_largest() {
         ])
         .lexicographically_largest()
     ));
+}
+
+#[test]
+fn fp_serde_roundtrip() {
+    use bincode;
+    let fp = Fp::one();
+    let ser = bincode::serialize(&fp).unwrap();
+    let deser: Fp = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(fp, deser);
 }

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -2,7 +2,9 @@
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-
+use serde::{
+    self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::fp::Fp;
@@ -45,6 +47,91 @@ impl PartialEq for Fp2 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).unwrap_u8() == 1
+    }
+}
+
+
+impl Serialize for Fp2 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut fp2 = serializer.serialize_struct("struct Fp2", 2)?;
+        fp2.serialize_field("c0", &self.c0)?;
+        fp2.serialize_field("c1", &self.c1)?;
+        fp2.end()
+    }
+}
+
+
+impl<'de> Deserialize<'de> for Fp2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            C0,
+            C1,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct Fp2")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "c0" => Ok(Field::C0),
+                            "c1" => Ok(Field::C1),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Fp2Visitor;
+
+        impl<'de> Visitor<'de> for Fp2Visitor {
+            type Value = Fp2;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct Fp2")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Fp2, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let c0 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c1 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Fp2 { c0, c1 })
+            }
+        }
+
+        const FIELDS: &[&str] = &["c0", "c1"];
+        deserializer.deserialize_struct("Fp2", FIELDS, Fp2Visitor)
     }
 }
 
@@ -865,4 +952,19 @@ fn test_lexicographic_largest() {
         }
         .lexicographically_largest()
     ));
+}
+
+#[test]
+fn fp2_serde_roundtrip() {
+    use bincode;
+
+    let fp2 = Fp2{
+        c0: Fp::one(),
+        c1: Fp::one(),
+    };
+
+    let ser = bincode::serialize(&fp2).unwrap();
+    let deser: Fp2 = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(fp2, deser);
 }

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -4,6 +4,10 @@ use crate::fp2::*;
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use serde::{
+    self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
+
 
 /// This represents an element $c_0 + c_1 v + c_2 v^2$ of $\mathbb{F}_{p^6} = \mathbb{F}_{p^2} / v^3 - u - 1$.
 pub struct Fp6 {
@@ -55,6 +59,96 @@ impl Default for Fp6 {
 impl fmt::Debug for Fp6 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?} + ({:?})*v + ({:?})*v^2", self.c0, self.c1, self.c2)
+    }
+}
+
+
+impl Serialize for Fp6 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut fp2 = serializer.serialize_struct("struct Fp6", 3)?;
+        fp2.serialize_field("c0", &self.c0)?;
+        fp2.serialize_field("c1", &self.c1)?;
+        fp2.serialize_field("c2", &self.c2)?;
+        fp2.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Fp6 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            C0,
+            C1,
+            C2,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct Fp6")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "c0" => Ok(Field::C0),
+                            "c1" => Ok(Field::C1),
+                            "c2" => Ok(Field::C2),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Fp6Visitor;
+
+        impl<'de> Visitor<'de> for Fp6Visitor {
+            type Value = Fp6;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct Fp6")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Fp6, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let c0 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c1 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c2 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Fp6 { c0, c1, c2 })
+            }
+        }
+
+        const FIELDS: &[&str] = &["c0", "c1", "c2"];
+        deserializer.deserialize_struct("Fp6", FIELDS, Fp6Visitor)
     }
 }
 
@@ -505,3 +599,20 @@ fn test_arithmetic() {
     );
     assert_eq!(&a.invert().unwrap() * &a, Fp6::one());
 }
+
+#[test]
+fn fp6_serde_roundtrip() {
+    use bincode;
+
+    let fp6 = Fp6{
+        c0: Fp2::one(),
+        c1: Fp2::one(),
+        c2: Fp2::one(),
+    };
+
+    let ser = bincode::serialize(&fp6).unwrap();
+    let deser: Fp6 = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(fp6, deser);
+}
+

--- a/src/multiscalar_mul.rs
+++ b/src/multiscalar_mul.rs
@@ -275,6 +275,7 @@ fn log2(x: usize) -> u32 {
 }
 
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
 
     #[cfg(feature = "std")]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -4,7 +4,7 @@
 use core::convert::TryFrom;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use core::fmt;
-use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Shr, Sub, SubAssign, BitAnd, BitXor};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign, BitAnd, BitXor};
 use std::iter::{Sum, Product};
 use std::borrow::Borrow;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -1277,6 +1277,7 @@ fn test_and() {
     assert_eq!(a & -a, Scalar::zero());
 }
 
+#[test]
 fn test_iter_sum() {
     let scalars = vec![Scalar::one(), Scalar::one()];
     let res: Scalar = scalars.iter().sum();


### PR DESCRIPTION
- Provides `serde` support for the `Fp`, `Fp2` & `Fp6` data structures.

- Implements tests for each one of them.

Closes #12 and unblocks #10 & #11