### PR TITLE
Impl `random` for `Scalar`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 rayon = "1.3.0"
 serde = "1.0.106"
+rand = "0.7.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 #![allow(clippy::suspicious_arithmetic_impl)]
 
 extern crate serde;
+extern crate rand;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
Provided anything that implements `RNG` + `CryptoRng`
the library generates a random `Scalar`.

- We cut down the bytes to just use 254bits of randomness.
On this way the `from_bytes()` method can never fail.