### PR TITLE
Update subtle dep & bump lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/dusk-network/bls12_381"
 license = "MIT/Apache-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
-version = "0.1.3"
+version = "0.1.4"
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]
 categories =["Algorithms", "Cryptography", "Development tools"]
 edition = "2018"
@@ -33,7 +33,7 @@ harness = false
 required-features = ["groups"]
 
 [dependencies.subtle]
-version = "2.2.1"
+version = "2.3.0"
 default-features = false
 
 [features]


### PR DESCRIPTION
With this we will be able to transfor `CtOption<T>` into `Option<T>`. 

See: https://github.com/dalek-cryptography/subtle/pull/75