### PR TITLE
no-std pairing capability

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -28,7 +28,7 @@ jobs:
             command: test
             args: --release
 
-  test_nightly:
+  test_nightly_no_std:
       name: Nightly tests
       runs-on: ubuntu-latest
       steps:
@@ -40,6 +40,19 @@ jobs:
           with:
             command: test
             args: --release --no-default-features
+
+  test_nightly_serde:
+      name: Nightly tests
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+        - uses: actions-rs/cargo@v1
+          with:
+            command: test
+            args: --release --features serde_req
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 24-12-20
+### Changed
+- no-std compatibility for pairings feature
+- isolate serde with `serde_req` feature
+
 ## [0.3.0] - 08-11-20
 ### Changed
 - no-std compatibility

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ version = "2.3.0"
 default-features = false
 
 [features]
-default = ["groups", "pairings", "alloc", "std", "endo", "serde_req"]
+default = ["groups", "pairings", "alloc", "std", "endo"]
 groups = []
 pairings = ["groups"]
 alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/dusk-network/bls12_381"
 license = "MIT/Apache-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
-version = "0.3.0"
+version = "0.4.0"
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]
 categories =["Algorithms", "Cryptography", "Development tools"]
 edition = "2018"
@@ -15,10 +15,10 @@ exclude = [".github/workflows/ci.yml",
 ]
 
 [dependencies]
-byteorder = { version = "1.3.4", default-features = false }
+byteorder = {version = "1.3.4", default-features = false}
 rayon = "1.3.0"
-serde = { version = "1.0.106", default-features = false }
-rand_core = "0.5.1"
+serde = {version = "1.0.106", optional = true}
+rand_core = "0.6"
 canonical = {version = "0.4", optional = true}
 canonical_derive = {version = "0.4", optional = true}
 
@@ -40,11 +40,12 @@ version = "2.3.0"
 default-features = false
 
 [features]
-default = ["groups", "pairings", "alloc", "std" ,"endo"]
+default = ["groups", "pairings", "alloc", "std", "endo", "serde_req"]
 groups = []
 pairings = ["groups"]
 alloc = []
 nightly = ["subtle/nightly"]
 std = ["alloc"]
 canon = ["canonical", "canonical_derive"]
+serde_req = ["serde", "std"]
 endo = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 [dev-dependencies]
 criterion = "0.2.11"
 bincode = "1"
-rand = "0.7.0"
+rand = "0.8"
 
 [[bench]]
 name = "groups"

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -917,6 +917,7 @@ fn test_lexicographic_largest() {
 }
 
 #[test]
+#[cfg(feature = "serde_req")]
 fn fp_serde_roundtrip() {
     use bincode;
     let fp = Fp::one();

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -4,6 +4,8 @@
 use core::convert::TryFrom;
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+#[cfg(feature = "serde_req")]
 use serde::{
     self, de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,
 };
@@ -54,6 +56,7 @@ impl PartialEq for Fp {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl Serialize for Fp {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -68,6 +71,7 @@ impl Serialize for Fp {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl<'de> Deserialize<'de> for Fp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -957,6 +957,7 @@ fn test_lexicographic_largest() {
 }
 
 #[test]
+#[cfg(feature = "serde_req")]
 fn fp2_serde_roundtrip() {
     use bincode;
 

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -2,10 +2,12 @@
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+#[cfg(feature = "serde_req")]
 use serde::{
     self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
 };
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use crate::fp::Fp;
 
@@ -50,6 +52,7 @@ impl PartialEq for Fp2 {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl Serialize for Fp2 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -62,6 +65,7 @@ impl Serialize for Fp2 {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl<'de> Deserialize<'de> for Fp2 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -74,7 +74,7 @@ impl<'de> Deserialize<'de> for Fp2 {
         enum Field {
             C0,
             C1,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -3,10 +3,12 @@ use crate::fp2::*;
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+#[cfg(feature = "serde_req")]
 use serde::{
     self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
 };
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// This represents an element $c_0 + c_1 v + c_2 v^2$ of $\mathbb{F}_{p^6} = \mathbb{F}_{p^2} / v^3 - u - 1$.
 pub struct Fp6 {
@@ -61,6 +63,7 @@ impl fmt::Debug for Fp6 {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl Serialize for Fp6 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -74,6 +77,7 @@ impl Serialize for Fp6 {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl<'de> Deserialize<'de> for Fp6 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -603,6 +603,7 @@ fn test_arithmetic() {
 }
 
 #[test]
+#[cfg(feature = "serde_req")]
 fn fp6_serde_roundtrip() {
     use bincode;
 

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -87,7 +87,7 @@ impl<'de> Deserialize<'de> for Fp6 {
             C0,
             C1,
             C2,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -1507,6 +1507,7 @@ fn test_batch_normalize() {
 }
 
 #[test]
+#[cfg(feature = "serde_req")]
 fn g1_affine_serde_roundtrip() {
     use bincode;
 

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -3,8 +3,10 @@
 use core::borrow::Borrow;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+#[cfg(feature = "serde_req")]
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::fp::Fp;
 use crate::BlsScalar;
@@ -52,6 +54,7 @@ impl From<G1Projective> for G1Affine {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl Serialize for G1Affine {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -66,6 +69,7 @@ impl Serialize for G1Affine {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl<'de> Deserialize<'de> for G1Affine {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -4,6 +4,7 @@ use core::borrow::Borrow;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+#[cfg(feature = "serde_req")]
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -87,6 +88,7 @@ impl PartialEq for G2Affine {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl Serialize for G2Affine {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -101,6 +103,7 @@ impl Serialize for G2Affine {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl<'de> Deserialize<'de> for G2Affine {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -1973,6 +1973,7 @@ fn test_batch_normalize() {
 }
 
 #[test]
+#[cfg(feature = "serde_req")]
 fn g2_affine_serde_roundtrip() {
     use bincode;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,9 @@ mod fp12;
 mod fp6;
 
 // The BLS parameter x for BLS12-381 is -0xd201000000010000
+#[allow(dead_code)]
 const BLS_X: u64 = 0xd201000000010000;
+#[allow(dead_code)]
 const BLS_X_IS_NEGATIVE: bool = true;
 
 #[cfg(feature = "pairings")]
@@ -81,5 +83,5 @@ pub use pairings::{pairing, Gt, MillerLoopResult};
 #[cfg(all(feature = "pairings", feature = "alloc"))]
 pub use pairings::{multi_miller_loop, G2Prepared};
 
-#[cfg(feature = "groups")]
+#[cfg(all(feature = "groups", feature = "std"))]
 pub mod multiscalar_mul;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,9 @@ mod fp12;
 mod fp6;
 
 // The BLS parameter x for BLS12-381 is -0xd201000000010000
-#[allow(dead_code)]
+#[cfg(feature = "groups")]
 const BLS_X: u64 = 0xd201000000010000;
-#[allow(dead_code)]
+#[cfg(feature = "groups")]
 const BLS_X_IS_NEGATIVE: bool = true;
 
 #[cfg(feature = "pairings")]

--- a/src/multiscalar_mul.rs
+++ b/src/multiscalar_mul.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use byteorder;
 
-#[cfg(feature = "std")]
 /// Performs multiscalar multiplication reliying on Pippenger's algorithm.
 /// This method was taken from `curve25519-dalek` and was originally made by
 /// Oleg Andreev <oleganza@gmail.com>.
@@ -178,7 +177,6 @@ fn to_radix_2w(scalar: &Scalar, w: usize) -> [i8; 43] {
     digits
 }
 
-#[cfg(feature = "std")]
 /// Performs a Variable Base Multiscalar Multiplication.
 pub fn msm_variable_base(points: &[G1Affine], scalars: &[Scalar]) -> G1Projective {
     use rayon::prelude::*;
@@ -278,7 +276,6 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
 
-    #[cfg(feature = "std")]
     #[test]
     fn pippenger_test() {
         // Reuse points across different tests
@@ -309,7 +306,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn msm_variable_base_test() {
         let points = vec![G1Affine::generator()];

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -4,10 +4,13 @@ use crate::fp6::Fp6;
 use crate::{BlsScalar, G1Affine, G2Affine, G2Projective, BLS_X, BLS_X_IS_NEGATIVE};
 
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+#[cfg(feature = "serde_req")]
 use serde::{
     self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
 };
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -293,6 +296,7 @@ pub struct G2Prepared {
     coeffs: Vec<(Fp2, Fp2, Fp2)>,
 }
 
+#[cfg(feature = "serde_req")]
 impl Serialize for G2Prepared {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -308,6 +312,7 @@ impl Serialize for G2Prepared {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl<'de> Deserialize<'de> for G2Prepared {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -759,6 +759,7 @@ fn test_multi_miller_loop() {
 }
 
 #[test]
+#[cfg(feature = "serde_req")]
 fn g2_prepared_serde_roundtrip() {
     use bincode;
 

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -321,7 +321,7 @@ impl<'de> Deserialize<'de> for G2Prepared {
         enum Field {
             Choice,
             Coeffs,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1378,6 +1378,7 @@ fn test_iter_prod() {
 }
 
 #[test]
+#[cfg(feature = "serde_req")]
 fn serde_bincode_scalar_roundtrip() {
     use bincode;
     let scalar = -Scalar::from(3u64);

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -13,8 +13,10 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, BitAnd, BitXor, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::{CryptoRng, RngCore};
-use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+
+#[cfg(feature = "serde_req")]
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Represents an element of the scalar field $\mathbb{F}_q$ of the BLS12-381 elliptic
 /// curve construction.
@@ -88,6 +90,7 @@ impl ConditionallySelectable for Scalar {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl Serialize for Scalar {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -102,6 +105,7 @@ impl Serialize for Scalar {
     }
 }
 
+#[cfg(feature = "serde_req")]
 impl<'de> Deserialize<'de> for Scalar {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
Except for Pippenger's algorithm, the pairing capabilities of the library are `no-std` compliant.

This way, we can declare structures that depend on `G1Affine` (eg PLONK proof)

`serde` was isolated as a feature requirement because it conflicts with the `no-std` environment we need to create.