### PR TITLE
Remove unnecesary .into()s from Canon impls

### DIFF
--- a/src/g1.rs
+++ b/src/g1.rs
@@ -40,7 +40,7 @@ impl Canon for G1Affine {
 
         bytes.copy_from_slice(source.read_bytes(Self::SIZE));
 
-        Self::from_bytes(&bytes).map_err(|_| CanonError::InvalidEncoding.into())
+        Self::from_bytes(&bytes).map_err(|_| CanonError::InvalidEncoding)
     }
 
     fn encoded_len(&self) -> usize {

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -41,7 +41,7 @@ impl Canon for G2Affine {
 
         bytes.copy_from_slice(source.read_bytes(Self::SIZE));
 
-        Self::from_bytes(&bytes).map_err(|_| CanonError::InvalidEncoding.into())
+        Self::from_bytes(&bytes).map_err(|_| CanonError::InvalidEncoding)
     }
 
     fn encoded_len(&self) -> usize {


### PR DESCRIPTION
As per this messages: 
https://github.com/dusk-network/bls12_381/pull/67#pullrequestreview-635549908
https://github.com/dusk-network/bls12_381/pull/67#discussion_r613195938