### PR TITLE
Use `rkyv/alloc` on `alloc` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `rkyv-impl` feature by bringing in `rkyv/alloc`
+- Make `g1` and `g2` `Archived*` structs only available on `rkyv-impl` 
+
 ## [0.11.1] - 2022-10-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `rkyv-impl` feature by bringing in `rkyv/alloc`
+- Fixed `rkyv-impl` feature by bringing in `rkyv/alloc` on `alloc` feature
 - Make `g1` and `g2` `Archived*` structs only available on `rkyv-impl` 
 
 ## [0.11.1] - 2022-10-19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 [dev-dependencies]
 criterion = "0.2.11"
 bincode = "1"
+rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
 
 [[bench]]
 name = "groups"
@@ -58,6 +59,6 @@ pairings = ["groups"]
 alloc = []
 nightly = ["subtle/nightly"]
 canon = ["canonical", "canonical_derive"]
-rkyv-impl = ["rkyv", "bytecheck"]
+rkyv-impl = ["rkyv", "rkyv/alloc", "bytecheck"]
 serde_req = ["serde", "std"]
 endo = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,13 +64,13 @@ mod g2;
 #[cfg(feature = "groups")]
 pub use g1::{G1Affine, G1Projective};
 
-#[cfg(all(feature = "groups", feature = "rkyv"))]
+#[cfg(all(feature = "groups", feature = "rkyv-impl"))]
 pub use g1::{ArchivedG1Affine, G1AffineResolver};
 
 #[cfg(feature = "groups")]
 pub use g2::{G2Affine, G2Projective};
 
-#[cfg(all(feature = "groups", feature = "rkyv"))]
+#[cfg(all(feature = "groups", feature = "rkyv-impl"))]
 pub use g2::{ArchivedG2Affine, G2AffineResolver};
 
 #[cfg(feature = "groups")]
@@ -90,13 +90,13 @@ mod pairings;
 #[cfg(feature = "pairings")]
 pub use pairings::{pairing, Gt, MillerLoopResult};
 
-#[cfg(all(feature = "pairings", feature = "rkyv"))]
+#[cfg(all(feature = "pairings", feature = "rkyv-impl"))]
 pub use pairings::{ArchivedGt, ArchivedMillerLoopResult, GtResolver, MillerLoopResultResolver};
 
 #[cfg(all(feature = "pairings", feature = "alloc"))]
 pub use pairings::{multi_miller_loop, G2Prepared};
 
-#[cfg(all(feature = "pairings", feature = "rkyv"))]
+#[cfg(all(feature = "pairings", feature = "rkyv-impl"))]
 pub use pairings::{ArchivedG2Prepared, G2PreparedResolver};
 
 #[cfg(all(feature = "groups", feature = "alloc"))]


### PR DESCRIPTION
This is necessary since the `Archive` impl for `Vec` is behind the `rkyv/alloc` feature.