### PR TITLE
Bump to v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3] - 2023-11-01
+
 ### Added
 
 - Add `uni_random` scalar generation [#125]
@@ -240,7 +242,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#50]: https://github.com/dusk-network/bls12_381/issues/50
 
 <!-- Versions -->
-[Unreleased]: https://github.com/dusk-network/bls12_381/compare/v0.12.2...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381/compare/v0.12.3...HEAD
+[0.12.3]: https://github.com/dusk-network/bls12_381/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/dusk-network/bls12_381/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/dusk-network/bls12_381/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/dusk-network/bls12_381/compare/v0.11.3...v0.12.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/dusk-network/bls12_381"
 license = "MIT/Apache-2.0/MPL-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]


### PR DESCRIPTION
## [0.12.3] - 2023-11-01

### Added

- Add `uni_random` scalar generation [#125]

### Changed

- Change `Hash` derive on `Scalar` to explicit implementation [#106]

[0.12.3]: https://github.com/dusk-network/bls12_381/compare/v0.12.2...v0.12.3
