### PR TITLE
feat: add `from_var_bytes` to `Scalar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `from_var_bytes` to scalar
+
 ## [0.12.3] - 2023-11-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `from_var_bytes` to scalar
 
+### Changed
+
+- Change `Scalar::uni_random` to sample u64 without manipulating bits
+
 ## [0.12.3] - 2023-11-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `from_var_bytes` to scalar
 
-### Changed
-
-- Change `Scalar::uni_random` to sample u64 without manipulating bits
-
 ## [0.12.3] - 2023-11-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ sha2 = "0.9"
 sha3 = "0.9"
 # Dev-dependencies added by Dusk
 bincode = "1"
-rand = "0.8"
 rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
 quickcheck = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/dusk-network/bls12_381"
 license = "MIT/Apache-2.0/MPL-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]
@@ -33,6 +33,7 @@ sha3 = "0.9"
 # Dev-dependencies added by Dusk
 bincode = "1"
 rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
+quickcheck = "1"
 
 [[bench]]
 name = "groups"
@@ -75,6 +76,10 @@ default-features = false
 optional = true
 
 # Start of dependencies added by Dusk
+[dependencies.blake2b_simd]
+version = "1.0"
+default-features = false
+
 [dependencies.byteorder]
 version = "1"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = "0.9"
 sha3 = "0.9"
 # Dev-dependencies added by Dusk
 bincode = "1"
+rand = "0.8"
 rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
 quickcheck = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/dusk-network/bls12_381"
 license = "MIT/Apache-2.0/MPL-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
-version = "0.12.4"
+version = "0.12.3"
 edition = "2021"
 
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]

--- a/src/scalar/dusk.rs
+++ b/src/scalar/dusk.rs
@@ -281,23 +281,20 @@ impl Scalar {
     where
         R: RngCore + CryptoRng,
     {
-        loop {
-            let s0 = rng.next_u64();
-            let s1 = rng.next_u64();
-            let s2 = rng.next_u64();
-            let s3 = rng.next_u64();
+        let mut buf = [0; 32];
+        let mut scalar: Option<Self> = None;
 
-            let bx = s3 <= MODULUS.0[3];
-            let b1 = bx && MODULUS.0[0] > s0;
-            let b2 = bx && (MODULUS.0[1] + b1 as u64) > s1;
-            let b3 = bx && (MODULUS.0[2] + b2 as u64) > s2;
-            let b4 = bx && (MODULUS.0[3] + b3 as u64) > s3;
-
-            // there is a borrow; hence, in range
-            if b4 {
-                return Self::from_raw([s0, s1, s2, s3]);
-            }
+        // We loop as long as it takes to generate a valid scalar.
+        // As long as the random number generator is implemented properly, this
+        // loop will terminate.
+        while scalar == None {
+            rng.fill_bytes(&mut buf);
+            // Since modulus has at most 255 bits, we can zero the MSB and like
+            // this improve our chances of hitting a valid scalar to above 50%
+            buf[32 - 1] &= 0b0111_1111;
+            scalar = Self::from_bytes(&buf).into();
         }
+        scalar.unwrap()
     }
 
     /// Creates a `Scalar` from arbitrary bytes by hashing the input with BLAKE2b into a 256-bits
@@ -484,9 +481,6 @@ fn test_scalar_eq_and_hash() {
 mod fuzz {
     use alloc::vec::Vec;
 
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-
     use crate::scalar::{Scalar, MODULUS};
     use crate::util::sbb;
 
@@ -504,15 +498,6 @@ mod fuzz {
     quickcheck::quickcheck! {
         fn prop_scalar_from_raw_bytes(bytes: Vec<u8>) -> bool {
             let scalar = Scalar::from_var_bytes(&bytes);
-
-            is_scalar_in_range(&scalar)
-        }
-    }
-
-    quickcheck::quickcheck! {
-        fn prop_scalar_uni_random(seed: u64) -> bool {
-            let rng = &mut StdRng::seed_from_u64(seed);
-            let scalar = Scalar::uni_random(rng);
 
             is_scalar_in_range(&scalar)
         }

--- a/src/scalar/dusk.rs
+++ b/src/scalar/dusk.rs
@@ -297,6 +297,36 @@ impl Scalar {
         scalar.unwrap()
     }
 
+    /// Creates a `Scalar` from arbitrary bytes by hashing the input with BLAKE2b into a 256-bits
+    /// number, and then converting it into its `Scalar` representation.
+    pub fn from_var_bytes(input: &[u8]) -> Scalar {
+        let state = blake2b_simd::Params::new()
+            .hash_length(32)
+            .to_state()
+            .update(input)
+            .finalize();
+
+        let h = state.as_bytes();
+        let mut r = [0u64; 4];
+
+        // will be optmized by the compiler, depending on the available target
+        for i in 0..4 {
+            r[i] = u64::from_le_bytes([
+                h[i * 8],
+                h[i * 8 + 1],
+                h[i * 8 + 2],
+                h[i * 8 + 3],
+                h[i * 8 + 4],
+                h[i * 8 + 5],
+                h[i * 8 + 6],
+                h[i * 8 + 7],
+            ]);
+        }
+
+        // `from_raw` converts from arbitrary to congruent scalar
+        Self::from_raw(r)
+    }
+
     /// SHR impl
     #[inline]
     pub fn divn(&mut self, mut n: u32) {
@@ -445,4 +475,28 @@ fn test_scalar_eq_and_hash() {
     // Check if hash results are consistent with PartialEq results
     assert_eq!(hash_r0, hash_r1);
     assert_ne!(hash_r0, hash_r2);
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod fuzz {
+    use alloc::vec::Vec;
+
+    use super::super::MODULUS;
+    use super::Scalar;
+    use crate::util::sbb;
+
+    quickcheck::quickcheck! {
+        fn prop_scalar_from_raw_bytes(bytes: Vec<u8>) -> bool {
+            let Scalar(s) = Scalar::from_var_bytes(&bytes);
+            let Scalar(m) = MODULUS;
+
+            // subtraction against modulus must underflow
+            let (_, borrow) = sbb(s[0], m[0], 0);
+            let (_, borrow) = sbb(s[1], m[1], borrow);
+            let (_, borrow) = sbb(s[2], m[2], borrow);
+            let (_, borrow) = sbb(s[3], m[3], borrow);
+
+            ((borrow as u8) & 1) == 1
+        }
+    }
 }

--- a/src/scalar/dusk.rs
+++ b/src/scalar/dusk.rs
@@ -481,8 +481,7 @@ fn test_scalar_eq_and_hash() {
 mod fuzz {
     use alloc::vec::Vec;
 
-    use super::super::MODULUS;
-    use super::Scalar;
+    use crate::scalar::{Scalar, MODULUS};
     use crate::util::sbb;
 
     quickcheck::quickcheck! {
@@ -491,12 +490,9 @@ mod fuzz {
             let Scalar(m) = MODULUS;
 
             // subtraction against modulus must underflow
-            let (_, borrow) = sbb(s[0], m[0], 0);
-            let (_, borrow) = sbb(s[1], m[1], borrow);
-            let (_, borrow) = sbb(s[2], m[2], borrow);
-            let (_, borrow) = sbb(s[3], m[3], borrow);
+            let borrow = s.iter().zip(m.iter()).fold(0, |borrow, (&s, &m)| sbb(s, m, borrow).1);
 
-            ((borrow as u8) & 1) == 1
+            (borrow >> 63) == 1
         }
     }
 }


### PR DESCRIPTION
This commit introduces `from_var_bytes` for `Scalar`, a function that will take arbitrary slices, hash with BLAKE2b into 256-bit numbers, and perform a modulus multiplication to produce valid scalars.

Such functionality is required for downstream protocols such as Phoenix or Rusk contract ID computation. They produce arbitrary bytes, being either asymmetric key exchange protocols or network transaction payload, annd perform off-circuit field operations with such inputs.