### PR TITLE
feat: add `from_var_bytes` to `Scalar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `from_var_bytes` to scalar [#133]
+
 ## [0.12.3] - 2023-11-01
 
 ### Added
@@ -220,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `S` to `TWO_ADACITY` and export it
 
 <!-- Issues -->
+[#133]: https://github.com/dusk-network/bls12_381/issues/133
 [#125]: https://github.com/dusk-network/bls12_381/issues/125
 [#117]: https://github.com/dusk-network/bls12_381/issues/117
 [#109]: https://github.com/dusk-network/bls12_381/issues/109

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ sha3 = "0.9"
 # Dev-dependencies added by Dusk
 bincode = "1"
 rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
+quickcheck = "1"
 
 [[bench]]
 name = "groups"
@@ -75,6 +76,10 @@ default-features = false
 optional = true
 
 # Start of dependencies added by Dusk
+[dependencies.blake2b_simd]
+version = "1.0"
+default-features = false
+
 [dependencies.byteorder]
 version = "1"
 default-features = false


### PR DESCRIPTION
This commit introduces `from_var_bytes`, a `Scalar` function that will take arbitrary slices, hash with BLAKE2b into 256-bit numbers, and perform a modulus multiplication to produce valid scalars.

Resolves #133