### PR TITLE
Bump to version 0.13.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/dusk-network/bls12_381"
 license = "MIT/Apache-2.0/MPL-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
-version = "0.12.3"
+version = "0.13.0-rc.0"
 edition = "2021"
 
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]


### PR DESCRIPTION
### Removed

- Remove `uni_random` from scalar [#135]

### Added

- Add `from_var_bytes` to scalar [#133] and refactor and rename to `hash_to_scalar` [#137]
