### PR TITLE
Bump to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2023-12-13
+
 ### Removed
 
 - Remove `uni_random` from scalar [#135]
@@ -253,7 +255,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#50]: https://github.com/dusk-network/bls12_381/issues/50
 
 <!-- Versions -->
-[Unreleased]: https://github.com/dusk-network/bls12_381/compare/v0.12.3...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/dusk-network/bls12_381/compare/v0.12.3...v0.13.0
 [0.12.3]: https://github.com/dusk-network/bls12_381/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/dusk-network/bls12_381/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/dusk-network/bls12_381/compare/v0.12.0...v0.12.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/dusk-network/bls12_381"
 license = "MIT/Apache-2.0/MPL-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
-version = "0.13.0-rc.0"
+version = "0.13.0"
 edition = "2021"
 
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]


### PR DESCRIPTION
## [0.13.0] - 2023-12-13

### Removed

- Remove `uni_random` from scalar [#135]

### Added

- Add `from_var_bytes` to scalar [#133] and refactor and rename to `hash_to_scalar` [#137]


[0.13.0]: https://github.com/dusk-network/bls12_381/compare/v0.12.3...v0.13.0
