### PR TITLE
Raise MSRV to Rust 1.96.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Raise the minimum supported Rust version to 1.96.1
 - `hash_to_scalar` now takes an optional `domain: impl Into<Option<[u8; 32]>>` parameter for domain separation. Pass `None` for the byte-compatible legacy construction, or a `[u8; 32]` value to select the personalized domain-separated construction
 - Serde feature no longer has any std dependence [#3596]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0/MPL-2.0"
 name = "dusk-bls12_381"
 repository = "https://github.com/dusk-network/bls12_381"
 version = "0.14.2"
-rust-version = "1.85"
+rust-version = "1.96.1"
 edition = "2021"
 
 keywords = ["cryptography", "bls12_381", "zk-snarks", "ecc", "elliptic-curve"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 This crate provides an implementation of the BLS12-381 pairing-friendly elliptic curve construction.
 
 * **This implementation has not been reviewed or audited. Use at your own risk.**
-* This implementation targets Rust `1.56` or later.
+* This implementation targets Rust `1.96.1` or later.
 * This implementation does not require the Rust standard library.
 * All operations are constant time unless explicitly noted.
 

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -980,7 +980,7 @@ impl Group for G1Projective {
     fn random(mut rng: impl RngCore) -> Self {
         loop {
             let x = Fp::random(&mut rng);
-            let flip_sign = rng.next_u32() % 2 != 0;
+            let flip_sign = !rng.next_u32().is_multiple_of(2);
 
             // Obtain the corresponding y-coordinate given x as y = sqrt(x^3 + 4)
             let p = ((x.square() * x) + B).sqrt().map(|y| G1Affine {

--- a/src/g1/dusk.rs
+++ b/src/g1/dusk.rs
@@ -50,7 +50,9 @@ impl G1Affine {
         let mut z = [0u8; 8];
 
         bytes
-            .chunks_exact(8)
+            .as_chunks::<8>()
+            .0
+            .iter()
             .zip(x.iter_mut().chain(y.iter_mut()))
             .for_each(|(c, n)| {
                 z.copy_from_slice(c);

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -1128,7 +1128,7 @@ impl Group for G2Projective {
     fn random(mut rng: impl RngCore) -> Self {
         loop {
             let x = Fp2::random(&mut rng);
-            let flip_sign = rng.next_u32() % 2 != 0;
+            let flip_sign = !rng.next_u32().is_multiple_of(2);
 
             // Obtain the corresponding y-coordinate given x as y = sqrt(x^3 + 4)
             let p = ((x.square() * x) + B).sqrt().map(|y| G2Affine {

--- a/src/g2/dusk.rs
+++ b/src/g2/dusk.rs
@@ -57,7 +57,7 @@ impl G2Affine {
             .chain(xc1.iter_mut())
             .chain(yc0.iter_mut())
             .chain(yc1.iter_mut())
-            .zip(bytes.chunks_exact(8))
+            .zip(bytes.as_chunks::<8>().0.iter())
             .for_each(|(n, c)| {
                 z.copy_from_slice(c);
                 *n = u64::from_le_bytes(z);

--- a/src/pairings/dusk/mod.rs
+++ b/src/pairings/dusk/mod.rs
@@ -20,7 +20,7 @@ impl G2Prepared {
     /// without any check.
     pub fn to_raw_bytes(&self) -> Vec<u8> {
         let mut bytes = alloc::vec![0u8; 288 * self.coeffs.len()];
-        let mut chunks = bytes.chunks_exact_mut(8);
+        let mut chunks = bytes.as_chunks_mut::<8>().0.iter_mut();
 
         self.coeffs.iter().for_each(|(a, b, c)| {
             a.c0.internal_repr()
@@ -49,7 +49,9 @@ impl G2Prepared {
     /// function is for trusted bytes where performance is critical.
     pub unsafe fn from_slice_unchecked(bytes: &[u8]) -> Self {
         let coeffs = bytes
-            .chunks_exact(288)
+            .as_chunks::<288>()
+            .0
+            .iter()
             .map(|c| {
                 let mut ac0 = [0u64; 6];
                 let mut ac1 = [0u64; 6];
@@ -65,7 +67,7 @@ impl G2Prepared {
                     .chain(bc1.iter_mut())
                     .chain(cc0.iter_mut())
                     .chain(cc1.iter_mut())
-                    .zip(c.chunks_exact(8))
+                    .zip(c.as_chunks::<8>().0.iter())
                     .for_each(|(n, c)| {
                         z.copy_from_slice(c);
                         *n = u64::from_le_bytes(z);


### PR DESCRIPTION
## Summary

- raise the declared MSRV from Rust 1.85 to 1.96.1
- update the README and changelog
- adopt standard-library helpers required by current Clippy guidance

## Validation

- \`make test\`
- \`make cq\`
- \`make check\`
- \`make no-std\`
- \`make doc\`
- benchmark compilation