### PR TITLE
Update Criterion to 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update Criterion to 0.8 and remove unused development dependencies
 - Raise the minimum supported Rust version to 1.96.1
 - `hash_to_scalar` now takes an optional `domain: impl Into<Option<[u8; 32]>>` parameter for domain separation. Pass `None` for the byte-compatible legacy construction, or a `[u8; 32]` value to select the personalized domain-separated construction
 - Serde feature no longer has any std dependence [#3596]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,11 @@ exclude = [
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 
 [dev-dependencies]
-csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
-criterion = "0.3"
+criterion = "0.8"
 hex = "0.4"
 rand_xorshift = "0.3"
 sha2 = "0.9"
 sha3 = "0.9"
-# Dev-dependencies added by Dusk
-bincode = "1"
 rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
 quickcheck = "1"
 serde_json = "1"

--- a/benches/groups.rs
+++ b/benches/groups.rs
@@ -5,7 +5,8 @@ extern crate dusk_bls12_381;
 use dusk_bls12_381::*;
 use dusk_bytes::Serializable;
 
-use criterion::{black_box, Criterion};
+use criterion::Criterion;
+use std::hint::black_box;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Pairings

--- a/benches/hash_to_curve.rs
+++ b/benches/hash_to_curve.rs
@@ -5,7 +5,8 @@ extern crate dusk_bls12_381;
 use dusk_bls12_381::hash_to_curve::*;
 use dusk_bls12_381::*;
 
-use criterion::{black_box, Criterion};
+use criterion::Criterion;
+use std::hint::black_box;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // G1Projective


### PR DESCRIPTION
## Summary

- update Criterion from 0.3 to 0.8
- use `std::hint::black_box` in benchmarks
- remove the unused `csv` and `bincode` development dependencies

Stacked on #170.

## Validation

- `make test`
- `make cq`
- `make check`
- `make no-std`
- `make doc`
- benchmark compilation