### PR TITLE
Reject non-canonical RKYV field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject non-canonical field and scalar representations during RKYV validation [#175]
 - Reject malformed `G2Prepared` Serde representations
 - Replace removed `CtOption::into_option` with `Option::from`
 - Reject non-boolean values in `Choice` wrapper (`From<u8>` masks input, `Serializable::from_bytes` and rkyv `CheckBytes` reject values other than 0/1)
@@ -276,6 +277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `S` to `TWO_ADACITY` and export it
 
 <!-- Issues -->
+[#175]: https://github.com/dusk-network/bls12_381/issues/175
 [#3596]: https://github.com/dusk-network/rusk/issues/3596
 [#168]: https://github.com/dusk-network/bls12_381/issues/168
 [#154]: https://github.com/dusk-network/bls12_381/issues/154

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ hex = "0.4"
 rand_xorshift = "0.3"
 sha2 = "0.9"
 sha3 = "0.9"
-rkyv = {version = "0.7", default-features = false, features = ["size_32"]}
+rkyv = {version = "0.7", default-features = false, features = ["size_32", "validation"]}
 quickcheck = "1"
 serde_json = "1"
 rand = "0.8"

--- a/src/dusk/archive.rs
+++ b/src/dusk/archive.rs
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use core::fmt;
+
+use bytecheck::{ErrorBox, TupleStructCheckError};
+
+use crate::util::sbb;
+
+#[derive(Debug)]
+struct SemanticCheckError(&'static str);
+
+impl fmt::Display for SemanticCheckError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl core::error::Error for SemanticCheckError {}
+
+pub(crate) fn invalid_tuple(field_index: usize, message: &'static str) -> TupleStructCheckError {
+    TupleStructCheckError {
+        field_index,
+        inner: ErrorBox::new(SemanticCheckError(message)),
+    }
+}
+
+pub(crate) fn limbs_are_canonical<const N: usize>(limbs: &[u64; N], modulus: &[u64; N]) -> bool {
+    let borrow = limbs
+        .iter()
+        .zip(modulus)
+        .fold(0, |borrow, (&limb, &modulus)| sbb(limb, modulus, borrow).1);
+
+    borrow != 0
+}

--- a/src/dusk/mod.rs
+++ b/src/dusk/mod.rs
@@ -6,6 +6,9 @@
 
 pub(crate) mod choice;
 
+#[cfg(feature = "rkyv-impl")]
+pub(crate) mod archive;
+
 #[cfg(all(feature = "groups", feature = "alloc"))]
 pub mod multiscalar_mul;
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -13,19 +13,13 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use crate::util::{adc, mac, sbb};
 
 #[cfg(feature = "rkyv-impl")]
-use bytecheck::CheckBytes;
-#[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 // The internal representation of this type is six 64-bit unsigned
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
 #[derive(Copy, Clone)]
-#[cfg_attr(
-    feature = "rkyv-impl",
-    derive(Archive, RkyvSerialize, RkyvDeserialize),
-    archive_attr(derive(CheckBytes))
-)]
+#[cfg_attr(feature = "rkyv-impl", derive(Archive, RkyvSerialize, RkyvDeserialize))]
 pub struct Fp(pub(crate) [u64; 6]);
 
 impl fmt::Debug for Fp {

--- a/src/fp/dusk.rs
+++ b/src/fp/dusk.rs
@@ -6,10 +6,95 @@
 
 use super::Fp;
 
+#[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
+use rkyv::Archived;
+
+#[cfg(feature = "rkyv-impl")]
+use super::MODULUS;
+#[cfg(feature = "rkyv-impl")]
+use crate::dusk::archive::{invalid_tuple, limbs_are_canonical};
+
+#[cfg(feature = "rkyv-impl")]
+impl<C: ?Sized> CheckBytes<C> for super::ArchivedFp
+where
+    Archived<[u64; 6]>: CheckBytes<C>,
+{
+    type Error = bytecheck::TupleStructCheckError;
+
+    unsafe fn check_bytes<'a>(
+        value: *const Self,
+        context: &mut C,
+    ) -> Result<&'a Self, Self::Error> {
+        let archived = unsafe {
+            <Archived<[u64; 6]> as CheckBytes<C>>::check_bytes(&raw const (*value).0, context)
+        }
+        .map_err(|error| bytecheck::TupleStructCheckError {
+            field_index: 0,
+            inner: bytecheck::ErrorBox::new(error),
+        })?;
+
+        let limbs: [u64; 6] =
+            rkyv::Deserialize::deserialize(archived, &mut rkyv::Infallible).unwrap();
+
+        if !limbs_are_canonical(&limbs, &MODULUS) {
+            return Err(invalid_tuple(0, "field element is not canonical"));
+        }
+
+        Ok(unsafe { &*value })
+    }
+}
+
 impl Fp {
     /// Internal representation of `Fp`
     pub const fn internal_repr(&self) -> &[u64; 6] {
         &self.0
+    }
+}
+
+#[cfg(all(test, feature = "rkyv-impl"))]
+mod rkyv_tests {
+    use super::*;
+
+    fn is_valid(value: &Fp) -> bool {
+        let bytes = rkyv::to_bytes::<_, 256>(value).unwrap();
+        let archived = unsafe { rkyv::archived_root::<Fp>(&bytes) };
+        let ptr = archived as *const Archived<Fp>;
+        unsafe { <Archived<Fp> as CheckBytes<()>>::check_bytes(ptr, &mut ()) }.is_ok()
+    }
+
+    #[test]
+    fn rejects_noncanonical_field_limbs() {
+        let mut largest = MODULUS;
+        largest[0] -= 1;
+
+        assert!(is_valid(&Fp::zero()));
+        assert!(is_valid(&Fp(largest)));
+        assert!(!is_valid(&Fp(MODULUS)));
+        assert!(!is_valid(&Fp([u64::MAX; 6])));
+
+        #[cfg(feature = "alloc")]
+        {
+            let bytes = rkyv::to_bytes::<_, 256>(&alloc::vec![Fp(MODULUS)]).unwrap();
+            assert!(rkyv::from_bytes::<alloc::vec::Vec<Fp>>(&bytes).is_err());
+        }
+    }
+
+    #[test]
+    fn containing_types_reject_noncanonical_field_limbs() {
+        let value = crate::fp2::Fp2 {
+            c0: Fp(MODULUS),
+            c1: Fp::zero(),
+        };
+        let bytes = rkyv::to_bytes::<_, 256>(&value).unwrap();
+        let archived = unsafe { rkyv::archived_root::<crate::fp2::Fp2>(&bytes) };
+        let ptr = archived as *const Archived<crate::fp2::Fp2>;
+
+        assert!(unsafe {
+            <Archived<crate::fp2::Fp2> as CheckBytes<()>>::check_bytes(ptr, &mut ())
+        }
+        .is_err());
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -18,8 +18,6 @@ use ff::{FieldBits, PrimeFieldBits};
 use crate::util::{adc, mac, sbb};
 
 #[cfg(feature = "rkyv-impl")]
-use bytecheck::CheckBytes;
-#[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 /// Represents an element of the scalar field $\mathbb{F}_q$ of the BLS12-381 elliptic
@@ -28,11 +26,7 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 // integers in little-endian order. `Scalar` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod q, with R = 2^256.
 #[derive(Clone, Copy, Eq)]
-#[cfg_attr(
-    feature = "rkyv-impl",
-    derive(Archive, RkyvSerialize, RkyvDeserialize),
-    archive_attr(derive(CheckBytes))
-)]
+#[cfg_attr(feature = "rkyv-impl", derive(Archive, RkyvSerialize, RkyvDeserialize))]
 pub struct Scalar(pub [u64; 4]);
 
 impl fmt::Debug for Scalar {

--- a/src/scalar/dusk.rs
+++ b/src/scalar/dusk.rs
@@ -13,6 +13,75 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::Scalar;
 
+#[cfg(feature = "rkyv-impl")]
+use bytecheck::CheckBytes;
+#[cfg(feature = "rkyv-impl")]
+use rkyv::Archived;
+
+#[cfg(feature = "rkyv-impl")]
+use super::MODULUS;
+#[cfg(feature = "rkyv-impl")]
+use crate::dusk::archive::{invalid_tuple, limbs_are_canonical};
+
+#[cfg(feature = "rkyv-impl")]
+impl<C: ?Sized> CheckBytes<C> for super::ArchivedScalar
+where
+    Archived<[u64; 4]>: CheckBytes<C>,
+{
+    type Error = bytecheck::TupleStructCheckError;
+
+    unsafe fn check_bytes<'a>(
+        value: *const Self,
+        context: &mut C,
+    ) -> Result<&'a Self, Self::Error> {
+        let archived = unsafe {
+            <Archived<[u64; 4]> as CheckBytes<C>>::check_bytes(&raw const (*value).0, context)
+        }
+        .map_err(|error| bytecheck::TupleStructCheckError {
+            field_index: 0,
+            inner: bytecheck::ErrorBox::new(error),
+        })?;
+
+        let limbs: [u64; 4] =
+            rkyv::Deserialize::deserialize(archived, &mut rkyv::Infallible).unwrap();
+
+        if !limbs_are_canonical(&limbs, &MODULUS.0) {
+            return Err(invalid_tuple(0, "scalar is not canonical"));
+        }
+
+        Ok(unsafe { &*value })
+    }
+}
+
+#[cfg(all(test, feature = "rkyv-impl"))]
+mod rkyv_tests {
+    use super::*;
+
+    fn is_valid(value: &Scalar) -> bool {
+        let bytes = rkyv::to_bytes::<_, 256>(value).unwrap();
+        let archived = unsafe { rkyv::archived_root::<Scalar>(&bytes) };
+        let ptr = archived as *const Archived<Scalar>;
+        unsafe { <Archived<Scalar> as CheckBytes<()>>::check_bytes(ptr, &mut ()) }.is_ok()
+    }
+
+    #[test]
+    fn rejects_noncanonical_scalar_limbs() {
+        let mut largest = MODULUS.0;
+        largest[0] -= 1;
+
+        assert!(is_valid(&Scalar::zero()));
+        assert!(is_valid(&Scalar(largest)));
+        assert!(!is_valid(&MODULUS));
+        assert!(!is_valid(&Scalar([u64::MAX; 4])));
+
+        #[cfg(feature = "alloc")]
+        {
+            let bytes = rkyv::to_bytes::<_, 256>(&alloc::vec![MODULUS]).unwrap();
+            assert!(rkyv::from_bytes::<alloc::vec::Vec<Scalar>>(&bytes).is_err());
+        }
+    }
+}
+
 /// Orders scalars by comparing their internal Montgomery-form limbs
 /// lexicographically (most-significant limb first).
 ///


### PR DESCRIPTION
## Summary

- validate archived `Fp` and `Scalar` limbs against their moduli
- preserve the existing RKYV layout and valid round trips
- cover direct and nested non-canonical representations

The derive attributes on the base type declarations must stop generating structural `CheckBytes` implementations so the semantic implementations can replace them. The custom validation itself remains confined to the Dusk modules.

## Validation

- `make cq`
- `make test`
- `make check`
- `make no-std`

Closes #175.
